### PR TITLE
Add Support For surround_rec_interface.h

### DIFF
--- a/hal/audio_extn/surround_rec_interface.h
+++ b/hal/audio_extn/surround_rec_interface.h
@@ -1,0 +1,32 @@
+/*
+ * Extrapolated / reversed header for SSR
+ */
+
+#ifndef _SURROUND_REC_INTERFACE_H_
+#define _SURROUND_REC_INTERFACE_H_
+
+typedef char *get_param(void *arg);
+typedef void set_param(void *arg, const char *arg1);
+
+typedef struct get_param_data {
+    const char *name;
+    get_param *get_param_fn;
+} get_param_data_t;
+
+typedef struct set_param_data {
+    const char *name;
+    set_param *set_param_fn;
+} set_param_data_t;
+
+const get_param_data_t* surround_rec_get_get_param_data(void);
+
+const set_param_data_t* surround_rec_get_set_param_data(void);
+
+int surround_rec_init(void **arg, int arg1, int arg2, int arg3,
+                      int arg4, const char *arg5);
+
+void surround_rec_deinit(void *arg);
+
+void surround_rec_process(void *arg, const int16_t *arg1, int16_t *arg2);
+
+#endif /* #ifndef _SURROUND_REC_INTERFACE_H_ */


### PR DESCRIPTION
FAILED: target  C: libssrec <= hardware/qcom-caf/sdm845/audio/hal/audio_extn/ssr.c
Outputs: out/target/product/fajita/obj/SHARED_LIBRARIES/libssrec_intermediates/ssr.o
Error: exited with code: 1
Command: /bin/bash -c "PWD=/proc/self/cwd  prebuilts/clang/host/linux-x86/clang-r416183b1/bin/clang -I device/oneplus/sdm845-common/include -I hardware/qcom-caf/sdm845/audio/hal -I hardware/qcom-caf/sdm845/audio/hal/msm8974 -I external/tinyalsa/include -I external/tinycompress/include -I external/expat/lib -I system/media/audio_utils/include -I system/media/audio_route/include -I system/media/audio_effects/include -I out/target/product/fajita/obj/include/mm-audio/surround_sound_3mic -I out/target/product/fajita/obj/include/common/inc -I out/target/product/fajita/obj/KERNEL_OBJ/usr/include/audio -I out/target/product/fajita/obj/KERNEL_OBJ/usr/techpack/audio/include -I hardware/qcom-caf/sdm845/audio/hal/audio_extn -I out/target/product/fajita/obj/SHARED_LIBRARIES/libssrec_intermediates -I out/target/product/fajita/gen/SHARED_LIBRARIES/libssrec_intermediates  -Isystem/media/audio_utils/include -Isystem/media/audio/include -Isystem/core/libcutils/include_outside_system -Isystem/core/libutils/include -Isystem/unwinding/libbacktrace/include -Isystem/logging/liblog/include_vndk -Isystem/core/libsystem/include -Isystem/core/libprocessgroup/include -Isystem/core/libprocessgroup/include -Isystem/core/libcutils/include_outside_system -Isystem/core/libprocessgroup/include -Isystem/core/libcutils/include -Isystem/logging/liblog/include_vndk -Iexternal/tinyalsa/include -Iexternal/tinyalsa/include -Iexternal/tinycompress/include  -Iexternal/expat/lib -Iexternal/expat/lib -Isystem/core/libprocessgroup/include -Isystem/core/libprocessgroup/include -Iexternal/libcxx/include -Iexternal/libcxxabi/include -isystem out/soong/.intermediates/bionic/libc/libc/android_vendor.32_arm64_armv8-a_shared/gen/include -isystem bionic/libc/kernel/uapi -isystem bionic/libc/kernel/android/scsi -isystem bionic/libc/kernel/android/uapi -isystem bionic/libc/kernel/uapi/asm-arm64   -Iexternal/libcxxabi/include  -Ihardware/libhardware/include -Isystem/media/audio/include -Isystem/core/libcutils/include_outside_system -Isystem/core/libsystem/include -Isystem/bt/types -Isystem/core/libsystem/include -Iout/soong/.intermediates/vendor/aosp/build/soong/generated_kernel_includes/gen/usr/audio/include/uapi -Iout/soong/.intermediates/vendor/aosp/build/soong/generated_kernel_includes/gen/usr/include -Iout/soong/.intermediates/vendor/aosp/build/soong/generated_kernel_includes/gen/usr/include/audio -Iout/soong/.intermediates/vendor/aosp/build/soong/generated_kernel_includes/gen/usr/include/audio/include/uapi -Iout/soong/.intermediates/vendor/aosp/build/soong/generated_kernel_includes/gen/usr/techpack/audio/include   -isystem out/target/product/fajita/obj/include -c  -Werror=implicit-function-declaration -DANDROID -fmessage-length=0 -W -Wall -Wno-unused -Winit-self -Wpointer-arith -Wunreachable-code-loop-increment -no-canonical-prefixes -DNDEBUG -UDEBUG -fno-exceptions -Wno-multichar -O2 -g -fdebug-info-for-profiling -fno-strict-aliasing -Werror=date-time -Werror=pragma-pack -Werror=pragma-pack-suspicious-include -Werror=string-plus-int -Werror=unreachable-code-loop-increment -fdebug-prefix-map=/proc/self/cwd= -D__compiler_offsetof=__builtin_offsetof -faddrsig -fcommon -Werror=int-conversion -fexperimental-new-pass-manager -Wno-reserved-id-macro -Wno-unused-command-line-argument -fcolor-diagnostics -Wno-sign-compare -Wno-defaulted-function-deleted -Wno-inconsistent-missing-override -Wno-c99-designator -Wno-gnu-folding-constant -Wno-compound-token-split-by-macro -Wunguarded-availability -D__ANDROID_UNAVAILABLE_SYMBOLS_ARE_WEAK__ -ftrivial-auto-var-init=zero -enable-trivial-auto-var-init-zero-knowing-it-will-be-removed-from-clang -ffunction-sections -fdata-sections -fno-short-enums -funwind-tables -fstack-protector-strong -Wa,--noexecstack -D_FORTIFY_SOURCE=2 -Wstrict-aliasing=2 -Werror=return-type -Werror=non-virtual-dtor -Werror=address -Werror=sequence-point -Werror=format-security -nostdlibinc -march=armv8-a  -Bprebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/aarch64-linux-android/bin   -std=gnu99    -Wall -Werror -Wno-unused-function -Wno-unused-variable -DDO_NOT_CHECK_MANUAL_BINDER_INTERFACES -D__ANDROID_VNDK__ -D__ANDROID_VENDOR__ -fPIC -DANDROID_STRICT -target aarch64-linux-android32   -Werror=bool-operation -Werror=implicit-int-float-conversion -Werror=int-in-bool-context -Werror=int-to-pointer-cast -Werror=pointer-to-int-cast -Werror=string-compare -Werror=xor-used-as-pow -Wno-void-pointer-to-enum-cast -Wno-void-pointer-to-int-cast -Wno-pointer-to-int-cast -Werror=fortify-source -Werror=address-of-temporary -Werror=return-type -Wno-tautological-constant-compare -Wno-tautological-type-limit-compare -Wno-reorder-init-list -Wno-implicit-int-float-conversion -Wno-int-in-bool-context -Wno-sizeof-array-div -Wno-tautological-overlap-compare -Wno-deprecated-copy -Wno-range-loop-construct -Wno-misleading-indentation -Wno-zero-as-null-pointer-constant -Wno-deprecated-anon-enum-enum-conversion -Wno-deprecated-enum-enum-conversion -Wno-string-compare -Wno-enum-enum-conversion -Wno-enum-float-conversion -Wno-pessimizing-move -Wno-non-c-typedef-for-linkage -Wno-string-concatenation -MD -MF out/target/product/fajita/obj/SHARED_LIBRARIES/libssrec_intermediates/ssr.d -o out/target/product/fajita/obj/SHARED_LIBRARIES/libssrec_intermediates/ssr.o hardware/qcom-caf/sdm845/audio/hal/audio_extn/ssr.c"
Output:
[1mhardware/qcom-caf/sdm845/audio/hal/audio_extn/ssr.c:39:10: [0m[0;1;31mfatal error: [0m[1m'surround_rec_interface.h' file not found[0m
#include "surround_rec_interface.h"
[0;1;32m         ^~~~~~~~~~~~~~~~~~~~~~~~~~
[0m1 error generated.

